### PR TITLE
Use a specific FTXUI version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
+  GIT_TAG 7daeac25c003b14898f9ff9c6731ceb83ec55fd3
 )
 
 FetchContent_GetProperties(ftxui)


### PR DESCRIPTION
As the FTXUI library evolves, it may introduce breaking change. Using a
specific version prevents regression.

Fortunately, all the breaking changes introduces did not break this
project.